### PR TITLE
Fix accidentally hard-coded registered name of checkbox items

### DIFF
--- a/src/pages/committee/form/new.tsx
+++ b/src/pages/committee/form/new.tsx
@@ -602,7 +602,7 @@ const NewForm: PageFC = () => {
                                 ?.minLength && "必須項目です",
                             ]}
                             required
-                            {...register(`items.0.boxes` as const, {
+                            {...register(`items.${index}.boxes` as const, {
                               required: true,
                               minLength: 1,
                             })}


### PR DESCRIPTION
なんか質問項目の1つ目以外にチェックボックス使うと `boxes` が反映されないなと思ったら、テスト目的で `index` を0に固定して `register` したのを戻し忘れてた(最悪)