### PR TITLE
authNeue migration in existing pages

### DIFF
--- a/src/layouts/sidebar/index.tsx
+++ b/src/layouts/sidebar/index.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 
 import { pagesPath } from "../../utils/$path"
 
-import { useAuth } from "../../contexts/auth"
+import { useAuthNeue } from "../../contexts/auth"
 
 import { isUserRoleHigherThanIncluding } from "../../types/models/user/userRole"
 
@@ -15,7 +15,7 @@ import { Links } from "./links"
 import styles from "./index.module.scss"
 
 const Sidebar: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
-  const { sosUser, signout } = useAuth()
+  const { authState, signout } = useAuthNeue()
 
   const router = useRouter()
 
@@ -34,10 +34,10 @@ const Sidebar: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         <Links layout={layout} />
       </div>
       <div className={styles.bottomWrapper}>
-        {sosUser && (
+        {authState?.status === "bothSignedIn" && (
           <>
             {isUserRoleHigherThanIncluding({
-              userRole: sosUser.role,
+              userRole: authState.sosUser.role,
               criteria: "committee",
             }) && (
               <Link
@@ -66,8 +66,8 @@ const Sidebar: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
                 <i className={`jam-icon jam-user-circle ${styles.userIcon}`} />
                 <p
                   className={styles.userName}
-                  title={`${sosUser.name.last} ${sosUser.name.first}`}
-                >{`${sosUser.name.last} ${sosUser.name.first}`}</p>
+                  title={`${authState.sosUser.name.last} ${authState.sosUser.name.first}`}
+                >{`${authState.sosUser.name.last} ${authState.sosUser.name.first}`}</p>
               </a>
             </Link>
             <button

--- a/src/layouts/sidebar/links.tsx
+++ b/src/layouts/sidebar/links.tsx
@@ -6,7 +6,7 @@ import { PageOptions } from "next"
 
 import { pagesPath } from "../../utils/$path"
 
-import { useAuth } from "../../contexts/auth"
+import { useAuthNeue } from "../../contexts/auth"
 
 import { isUserRoleHigherThanIncluding } from "../../types/models/user/userRole"
 
@@ -14,7 +14,8 @@ import styles from "./links.module.scss"
 
 export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
   const router = useRouter()
-  const { firebaseUser, sosUser } = useAuth()
+  const { authState } = useAuthNeue()
+  if (authState === null || authState.status === "error") return null
 
   if (layout === "empty") return null
 
@@ -44,14 +45,14 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         href: pagesPath.login.$url(),
         title: "ログイン",
         icon: "log-in",
-        visible: () => !firebaseUser,
+        visible: () => authState.status === "signedOut",
         active: () => router.pathname === pagesPath.login.$url().pathname,
       },
       {
         href: pagesPath.signup.$url(),
         title: "アカウント登録",
         icon: "user-plus",
-        visible: () => !firebaseUser,
+        visible: () => authState.status === "signedOut",
         active: () => router.pathname === pagesPath.signup.$url().pathname,
       },
       {
@@ -59,23 +60,22 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         title: "アカウント情報登録",
         icon: "user-circle",
         visible: () =>
-          Boolean(firebaseUser) &&
-          Boolean(firebaseUser?.emailVerified) &&
-          Boolean(!sosUser),
+          authState.status === "firebaseSignedIn" &&
+          Boolean(authState.firebaseUser.emailVerified),
         active: () => router.pathname === pagesPath.init.$url().pathname,
       },
       {
         href: pagesPath.project.new.$url(),
         title: "企画応募",
         icon: "write",
-        visible: () => Boolean(sosUser),
+        visible: () => authState.status === "bothSignedIn",
         active: () => router.pathname === pagesPath.project.new.$url().pathname,
       },
       {
         href: pagesPath.mypage.$url(),
         title: "マイページ",
         icon: "user-circle",
-        visible: () => Boolean(sosUser),
+        visible: () => authState.status === "bothSignedIn",
         active: () => router.pathname === pagesPath.mypage.$url().pathname,
       },
     ],
@@ -86,9 +86,9 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         icon: "home",
         visible: () =>
           Boolean(
-            sosUser &&
+            authState.status === "bothSignedIn" &&
               isUserRoleHigherThanIncluding({
-                userRole: sosUser.role,
+                userRole: authState.sosUser.role,
                 criteria: "committee",
               })
           ),
@@ -100,9 +100,9 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         icon: "task-list",
         visible: () =>
           Boolean(
-            sosUser &&
+            authState.status === "bothSignedIn" &&
               isUserRoleHigherThanIncluding({
-                userRole: sosUser.role,
+                userRole: authState.sosUser.role,
                 criteria: "committee",
               })
           ),
@@ -115,9 +115,9 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
         icon: "users",
         visible: () =>
           Boolean(
-            sosUser &&
+            authState.status === "bothSignedIn" &&
               isUserRoleHigherThanIncluding({
-                userRole: sosUser.role,
+                userRole: authState.sosUser.role,
                 criteria: "committee_operator",
               })
           ),

--- a/src/pages/committee/form/new.tsx
+++ b/src/pages/committee/form/new.tsx
@@ -21,7 +21,7 @@ import type { FormItem } from "../../../types/models/form/item"
 
 import { createForm } from "../../../lib/api/form/createForm"
 
-import { useAuth } from "../../../contexts/auth"
+import { useAuthNeue } from "../../../contexts/auth"
 
 import { pagesPath } from "../../../utils/$path"
 
@@ -63,7 +63,7 @@ type Inputs = {
 }
 
 const NewForm: PageFC = () => {
-  const { idToken } = useAuth()
+  const { authState } = useAuthNeue()
 
   const router = useRouter()
 
@@ -100,7 +100,12 @@ const NewForm: PageFC = () => {
     attributes,
     items,
   }: Inputs) => {
-    if (!idToken) throw new Error("idToken must not be null")
+    if (authState === null || authState.firebaseUser == null) {
+      setUnknownError(true)
+      return
+    }
+
+    const idToken = await authState.firebaseUser.getIdToken()
 
     setError(undefined)
 

--- a/src/pages/email-verification.tsx
+++ b/src/pages/email-verification.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 
 import { PageFC } from "next"
 
-import { useAuth } from "../contexts/auth"
+import { useAuthNeue } from "../contexts/auth"
 
 import { Button, Panel } from "../components"
 
@@ -14,7 +14,7 @@ const EmailVerification: PageFC = () => {
     undefined | "mailSent" | "error"
   >(undefined)
 
-  const { sendEmailVerification } = useAuth()
+  const { sendEmailVerification } = useAuthNeue()
 
   const resendVerification = () => {
     setProcessing(true)

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -7,7 +7,7 @@ import { pagesPath } from "../utils/$path"
 
 import { useForm } from "react-hook-form"
 
-import { useAuth } from "../contexts/auth"
+import { useAuthNeue } from "../contexts/auth"
 
 import { Button, FormItemSpacer, TextField, Panel } from "../components"
 
@@ -34,7 +34,7 @@ const Login: PageFC = () => {
     mode: "onBlur",
   })
 
-  const { signin } = useAuth()
+  const { signin } = useAuthNeue()
 
   const onSubmit = async ({ email, password }: Inputs) => {
     setProcessing(true)

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -1,11 +1,13 @@
 import type { PageFC } from "next"
 
-import { useAuth } from "../contexts/auth"
+import { useAuthNeue } from "../contexts/auth"
 
 const Mypage: PageFC = () => {
-  const { sosUser } = useAuth()
+  const { authState } = useAuthNeue()
 
-  console.log(sosUser)
+  if (authState?.sosUser) {
+    console.log(authState.sosUser)
+  }
 
   return <></>
 }

--- a/src/pages/project/new.tsx
+++ b/src/pages/project/new.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router"
 
 import { pagesPath } from "../../utils/$path"
 
-import { useAuth } from "../../contexts/auth"
+import { useAuthNeue } from "../../contexts/auth"
 import { useMyProject } from "../../contexts/myProject"
 
 import { Button, Panel, Spinner } from "../../components"
@@ -11,13 +11,15 @@ import { Button, Panel, Spinner } from "../../components"
 import styles from "./new.module.scss"
 
 const NewProject: PageFC = () => {
-  const { idToken } = useAuth()
+  const { authState } = useAuthNeue()
   const { myProjectState, createPendingProject } = useMyProject()
 
   const router = useRouter()
 
   const createSampleProject = async () => {
-    if (!idToken) return
+    if (authState === null || authState.firebaseUser == null) return
+
+    const idToken = await authState.firebaseUser.getIdToken()
 
     await createPendingProject({
       props: {

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -4,7 +4,7 @@ import { PageFC } from "next"
 
 import { useForm } from "react-hook-form"
 
-import { useAuth } from "../contexts/auth"
+import { useAuthNeue } from "../contexts/auth"
 
 import { Button, FormItemSpacer, TextField, Panel } from "../components"
 
@@ -29,7 +29,7 @@ const Signup: PageFC = () => {
     mode: "onBlur",
   })
 
-  const { signup, sendEmailVerification } = useAuth()
+  const { signup, sendEmailVerification } = useAuthNeue()
 
   const onSubmit = async ({ email, password }: Inputs) => {
     setProcessing(true)


### PR DESCRIPTION
`setSosUser` の挙動を確認するのが面倒なので `/init` だけ後回し