### PR TITLE
Disable non-public pages in prd so far

### DIFF
--- a/src/contexts/auth/useRbpacRedirect.ts
+++ b/src/contexts/auth/useRbpacRedirect.ts
@@ -81,8 +81,9 @@ export const useRbpacRedirect = ({
             router.push(pagesPath.$url())
             addToast({ title: "ログアウトしました" })
           } else {
-            router.push(pagesPath.login.$url())
-            addToast({ title: "ログインしてください" })
+            router.push(pagesPath.$url())
+            // router.push(pagesPath.login.$url())
+            // addToast({ title: "ログインしてください" })
           }
           return
         }

--- a/src/layouts/sidebar/links.tsx
+++ b/src/layouts/sidebar/links.tsx
@@ -45,62 +45,62 @@ export const Links: FC<Pick<PageOptions, "layout">> = ({ layout }) => {
           authState.firebaseUser?.emailVerified !== false,
         active: () => router.pathname === pagesPath.$url().pathname,
       },
-      {
-        href: pagesPath.login.$url(),
-        title: "ログイン",
-        icon: "log-in-alt",
-        visible: () => authState.status === "signedOut",
-        active: () => router.pathname === pagesPath.login.$url().pathname,
-      },
-      {
-        href: pagesPath.signup.$url(),
-        title: "ユーザー登録",
-        icon: "user-plus",
-        visible: () => authState.status === "signedOut",
-        active: () => router.pathname === pagesPath.signup.$url().pathname,
-      },
-      {
-        href: pagesPath.email_verification.$url(),
-        title: "メールアドレス確認",
-        icon: "envelope",
-        visible: () => Boolean(authState.firebaseUser?.emailVerified === false),
-        active: () =>
-          router.pathname === pagesPath.email_verification.$url().pathname,
-      },
-      {
-        href: pagesPath.init.$url(),
-        title: "アカウント情報登録",
-        icon: "user-circle",
-        visible: () =>
-          authState.status === "firebaseSignedIn" &&
-          Boolean(authState.firebaseUser.emailVerified),
-        active: () => router.pathname === pagesPath.init.$url().pathname,
-      },
-      {
-        href: pagesPath.project.new.$url(),
-        title: "企画応募",
-        icon: "write",
-        visible: () => authState.status === "bothSignedIn",
-        active: () => router.pathname === pagesPath.project.new.$url().pathname,
-      },
-      {
-        href: pagesPath.project.form.$url(),
-        title: "申請",
-        icon: "task-list",
-        visible: () =>
-          authState.status === "bothSignedIn" &&
-          !myProjectState?.error &&
-          Boolean(myProjectState?.myProject),
-        active: () =>
-          router.pathname.startsWith(pagesPath.project.form.$url().pathname),
-      },
-      {
-        href: pagesPath.me.$url(),
-        title: "マイページ",
-        icon: "user-circle",
-        visible: () => authState.status === "bothSignedIn",
-        active: () => router.pathname === pagesPath.me.$url().pathname,
-      },
+      // {
+      //   href: pagesPath.login.$url(),
+      //   title: "ログイン",
+      //   icon: "log-in-alt",
+      //   visible: () => authState.status === "signedOut",
+      //   active: () => router.pathname === pagesPath.login.$url().pathname,
+      // },
+      // {
+      //   href: pagesPath.signup.$url(),
+      //   title: "ユーザー登録",
+      //   icon: "user-plus",
+      //   visible: () => authState.status === "signedOut",
+      //   active: () => router.pathname === pagesPath.signup.$url().pathname,
+      // },
+      // {
+      //   href: pagesPath.email_verification.$url(),
+      //   title: "メールアドレス確認",
+      //   icon: "envelope",
+      //   visible: () => Boolean(authState.firebaseUser?.emailVerified === false),
+      //   active: () =>
+      //     router.pathname === pagesPath.email_verification.$url().pathname,
+      // },
+      // {
+      //   href: pagesPath.init.$url(),
+      //   title: "アカウント情報登録",
+      //   icon: "user-circle",
+      //   visible: () =>
+      //     authState.status === "firebaseSignedIn" &&
+      //     Boolean(authState.firebaseUser.emailVerified),
+      //   active: () => router.pathname === pagesPath.init.$url().pathname,
+      // },
+      // {
+      //   href: pagesPath.project.new.$url(),
+      //   title: "企画応募",
+      //   icon: "write",
+      //   visible: () => authState.status === "bothSignedIn",
+      //   active: () => router.pathname === pagesPath.project.new.$url().pathname,
+      // },
+      // {
+      //   href: pagesPath.project.form.$url(),
+      //   title: "申請",
+      //   icon: "task-list",
+      //   visible: () =>
+      //     authState.status === "bothSignedIn" &&
+      //     !myProjectState?.error &&
+      //     Boolean(myProjectState?.myProject),
+      //   active: () =>
+      //     router.pathname.startsWith(pagesPath.project.form.$url().pathname),
+      // },
+      // {
+      //   href: pagesPath.me.$url(),
+      //   title: "マイページ",
+      //   icon: "user-circle",
+      //   visible: () => authState.status === "bothSignedIn",
+      //   active: () => router.pathname === pagesPath.me.$url().pathname,
+      // },
     ],
     committee: [
       {

--- a/src/pages/email-verification.tsx
+++ b/src/pages/email-verification.tsx
@@ -92,6 +92,6 @@ const EmailVerification: PageFC = () => {
   )
 }
 EmailVerification.layout = "default"
-EmailVerification.rbpac = { type: "lowerThanIncluding", role: "guest" }
+EmailVerification.rbpac = { type: "higherThanIncluding", role: "administrator" }
 
 export default EmailVerification

--- a/src/pages/init.tsx
+++ b/src/pages/init.tsx
@@ -263,6 +263,6 @@ const Init: PageFC = () => {
   )
 }
 Init.layout = "default"
-Init.rbpac = { type: "lowerThanIncluding", role: "guest" }
+Init.rbpac = { type: "higherThanIncluding", role: "administrator" }
 
 export default Init

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -146,6 +146,6 @@ const Login: PageFC = () => {
   )
 }
 Login.layout = "default"
-Login.rbpac = { type: "lowerThanIncluding", role: "guest" }
+Login.rbpac = { type: "higherThanIncluding", role: "administrator" }
 
 export default Login

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -135,6 +135,6 @@ const ResetPassword: PageFC = () => {
   )
 }
 ResetPassword.layout = "default"
-ResetPassword.rbpac = { type: "lowerThanIncluding", role: "guest" }
+ResetPassword.rbpac = { type: "higherThanIncluding", role: "administrator" }
 
 export default ResetPassword

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -165,6 +165,6 @@ const Signup: PageFC = () => {
   )
 }
 Signup.layout = "default"
-Signup.rbpac = { type: "lowerThanIncluding", role: "guest" }
+Signup.rbpac = { type: "higherThanIncluding", role: "administrator" }
 
 export default Signup


### PR DESCRIPTION
`rbpac`が`guest`のページ以外は特に触ってないけど、prdはまだFirebaseに繋がないから誰にもログイン済みアカウントは存在せず、`general`以上を要求する`rbpac`は全部トップページにリダイレクトされるのでOKということで