### PR TITLE
Use `:focus-visible` instead of `:focus` in Button hovered style

### DIFF
--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -16,7 +16,7 @@
   transition: background-color 150ms, color 150ms;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background-color: $color-brand-tint-200;
   }
 
@@ -35,7 +35,7 @@
     color: $color-brand-shade-200;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: $color-brand-tint-1000;
     }
 


### PR DESCRIPTION
Mac Safari なんかサポートしてないぐらいの気持ちだしOKということで