### PR TITLE
Allow `+` character in email address in dev env

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -105,7 +105,10 @@ const Login: PageFC = () => {
                   required
                   register={register("email", {
                     required: true,
-                    pattern: /^[\w\-._]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/,
+                    pattern:
+                      process.env.NEXT_PUBLIC_DEPLOY_ENV === "dev"
+                        ? /^[\w\-._+]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/
+                        : /^[\w\-._]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/,
                   })}
                 />
               </FormItemSpacer>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -106,7 +106,10 @@ const Signup: PageFC = () => {
                   required
                   register={register("email", {
                     required: true,
-                    pattern: /^[\w\-._]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/,
+                    pattern:
+                      process.env.NEXT_PUBLIC_DEPLOY_ENV === "dev"
+                        ? /^[\w\-._+]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/
+                        : /^[\w\-._]+@([\w\-._]+\.)?tsukuba\.ac\.jp$/,
                   })}
                 />
               </FormItemSpacer>


### PR DESCRIPTION
Gmail の task-specific email address ([ref](https://support.google.com/a/users/answer/9308648?hl=en)) を使うと alumni アドレス1つで複数アカウント作れてテストに便利そうなので、dev 環境でのみ `+` が入ったメールアドレスを許容