### PR TITLE
Print the error passed to reportError util in console in dev env

### DIFF
--- a/src/lib/errorTracking/reportError.ts
+++ b/src/lib/errorTracking/reportError.ts
@@ -4,5 +4,12 @@ import { captureException } from "@sentry/browser"
  * @returns The generated eventId
  */
 export const reportError = (message: string, data?: any): string => {
+  if (process.env.NEXT_PUBLIC_DEPLOY_ENV === "dev") {
+    console.error({
+      message,
+      ...data,
+    })
+  }
+
   return captureException(new Error(message), { extra: data })
 }


### PR DESCRIPTION
ユーザー環境で無駄にコンソールにエラー出したくないので `reportError` に渡されたエラーは Sentry に送るだけでコンソールには出していなかったが、手元の dev 環境では普段 Sentry を無効化しているのでエラーを見る術がなくなってしまっていた
dev 環境では毎回 `console.error` することにする