### PR TITLE
Enable trailingSlash option of Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,6 +53,7 @@ if (!/^https?:\/\/.+\/$/.test(process.env.NEXT_PUBLIC_FRONTEND_URL)) {
 /** @type {import('next/dist/next-server/server/config-shared').NextConfig} */
 const config = {
   reactStrictMode: true,
+  trailingSlash: true,
   async headers() {
     return [{ source: "/(.*)", headers: createSecureHeaders() }]
   },


### PR DESCRIPTION
Vercel にデプロイするとトップページ以外の全ページがイニシャルロードで404になってしまう(Next の `<Link />` で client side navigation を経ると問題なく表示される)問題への workaround として

ref: https://github.com/vercel/next.js/issues/9213#issuecomment-593247735