### PR TITLE
Ignore storybook-static dir in ESLint/Prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -30,5 +30,8 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
+# storybook
+storybook-static
+
 # pathpida
 src/utils/$path.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -32,5 +32,8 @@ yarn-error.log*
 
 *.md
 
+# storybook
+storybook-static
+
 # pathpida
 src/utils/$path.ts


### PR DESCRIPTION
なんか `make lint` で突然無数のエラーが出るようになったなと思ったら Storybook のビルドファイルが ignore されていなかったので