### PR TITLE
Enable `--frozen-lockfile` in `yarn install` by default

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true


### PR DESCRIPTION
follows up #723 