### PR TITLE
Fill className with empty string when className is not passed as a prop

### DIFF
--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -13,7 +13,7 @@ declare namespace Icon {
 
 const Icon: FC<Icon.Props> = ({
   icon,
-  className,
+  className = "",
   ariaHidden,
   ariaLabel,
   ...rest

--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -13,7 +13,7 @@ declare namespace Panel {
 
 const Panel: FC<Panel.Props> = ({
   style,
-  className,
+  className = "",
   hoverStyle = "none",
   children,
 }) => {


### PR DESCRIPTION
optional parameter にしながら default value を渡していなかったせいで、`className` を渡さないと `undefined` という class が付いてしまっていた
クリティカルではないが修正