### PR TITLE
Don't run  Eintegrated ESLint in builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,9 @@ if (!/^https?:\/\/.+\/$/.test(process.env.NEXT_PUBLIC_FRONTEND_URL)) {
 const config = {
   reactStrictMode: true,
   trailingSlash: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   async headers() {
     return [{ source: "/(.*)", headers: createSecureHeaders() }]
   },


### PR DESCRIPTION
ESLint どうせ CI で別に実行してるので、ただビルド時間伸ばすだけのビルド中 ESLint チェックは無効化する