### PR TITLE
Report error in fetching announcements from Contentful in server side rather than in client side

### DIFF
--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -2,10 +2,17 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { CaptureConsole, ExtraErrorData } from "@sentry/integrations"
 import * as Sentry from "@sentry/nextjs"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_DEPLOY_ENV + "-server",
+  normalizeDepth: 10,
+  integrations: [
+    new CaptureConsole({ levels: ["warn", "error", "debug", "assert"] }),
+    new ExtraErrorData({ depth: 10 }),
+  ],
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps

--- a/src/pages/announcement/[id].tsx
+++ b/src/pages/announcement/[id].tsx
@@ -9,36 +9,27 @@ import Link from "next/link"
 
 import styles from "./[id].module.scss"
 import { Head, Panel, ParagraphWithUrlParsing } from "src/components"
-import {
-  getAnnouncement,
-  getRecentAnnouncements,
-} from "src/lib/contentful/index"
+import { getAnnouncement, getAnnouncements } from "src/lib/contentful/index"
 
-import { reportError } from "src/lib/errorTracking"
-import type { PromiseType } from "src/types/utils"
+import type { Announcement } from "src/types/models/announcement"
 
 import { pagesPath } from "src/utils/$path"
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const res = await getRecentAnnouncements({ limit: 100 })
+  const { announcements } = await getAnnouncements({ limit: 100 })
   return {
-    paths:
-      res && "errorCode" in res
-        ? []
-        : res.map(({ id }) => ({ params: { id } })),
+    paths: announcements.map(({ id }) => ({ params: { id } })),
     fallback: "blocking",
   }
 }
 
 export const getStaticProps: GetStaticProps<
   {
-    announcement: PromiseType<ReturnType<typeof getAnnouncement>>
+    announcement: Announcement | null
   },
   { id: string }
 > = async ({ params }) => {
-  const announcement = params
-    ? await getAnnouncement({ id: params.id })
-    : { errorCode: "unknown" as const }
+  const announcement = params ? await getAnnouncement({ id: params.id }) : null
   return {
     props: {
       announcement,
@@ -47,82 +38,72 @@ export const getStaticProps: GetStaticProps<
   }
 }
 
-const Announcement: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
-  announcement,
-}) => {
-  if (!announcement || (announcement && "errorCode" in announcement)) {
-    reportError(
-      "failed to fetch specific announcement from Contentful",
-      announcement
-    )
-  }
-
-  return (
-    <div className={styles.wrapper}>
-      <Head
-        title={
-          announcement && "errorCode" in announcement
-            ? "お知らせが見つかりませんでした"
-            : announcement.title
-        }
-      />
-      {announcement && !("errorCode" in announcement) ? (
-        <>
-          <h1 className={styles.title}>{announcement.title}</h1>
-          <Panel style={{ padding: "48px" }}>
-            <div className={styles.articleWrapper}>
-              <div className={styles.textWrapper}>
-                <ParagraphWithUrlParsing
-                  text={announcement.text}
-                  normalTextClassName={styles.paragraph}
-                  urlClassName={styles.paragraph}
-                />
-              </div>
-              {announcement.links && (
-                <div className={styles.linksWrapper}>
-                  {announcement.links?.map(({ url, label }) => (
-                    <a
-                      target="_blank"
-                      href={url}
-                      rel="noopener noreferrer"
-                      key={url}
-                      className={styles.link}
-                    >
-                      <span
-                        className={`jam-icons jam-link ${styles.linkIcon}`}
-                      />
-                      {label ?? url}
-                    </a>
-                  ))}
+const AnnouncementPage: PageFC<InferGetStaticPropsType<typeof getStaticProps>> =
+  ({ announcement }) => {
+    return (
+      <div className={styles.wrapper}>
+        <Head
+          title={
+            announcement ? announcement.title : "お知らせが見つかりませんでした"
+          }
+        />
+        {announcement ? (
+          <>
+            <h1 className={styles.title}>{announcement.title}</h1>
+            <Panel style={{ padding: "48px" }}>
+              <div className={styles.articleWrapper}>
+                <div className={styles.textWrapper}>
+                  <ParagraphWithUrlParsing
+                    text={announcement.text}
+                    normalTextClassName={styles.paragraph}
+                    urlClassName={styles.paragraph}
+                  />
                 </div>
-              )}
-              <p className={styles.date}>
-                {dayjs(announcement.date).format("YYYY/M/D HH:mm")}
-              </p>
+                {announcement.links && (
+                  <div className={styles.linksWrapper}>
+                    {announcement.links?.map(({ url, label }) => (
+                      <a
+                        target="_blank"
+                        href={url}
+                        rel="noopener noreferrer"
+                        key={url}
+                        className={styles.link}
+                      >
+                        <span
+                          className={`jam-icons jam-link ${styles.linkIcon}`}
+                        />
+                        {label ?? url}
+                      </a>
+                    ))}
+                  </div>
+                )}
+                <p className={styles.date}>
+                  {dayjs(announcement.date).format("YYYY/M/D HH:mm")}
+                </p>
+              </div>
+            </Panel>
+          </>
+        ) : (
+          <Panel>
+            <div className={styles.emptyWrapper}>
+              <p>お探しのお知らせが見つかりませんでした</p>
             </div>
           </Panel>
-        </>
-      ) : (
-        <Panel>
-          <div className={styles.emptyWrapper}>
-            <p>お探しのお知らせが見つかりませんでした</p>
-          </div>
-        </Panel>
-      )}
-      <div className={styles.goBackButton}>
-        <Link href={pagesPath.$url()}>
-          <a className={styles.goBackButtonText}>
-            <span
-              className={`jam-icons jam-arrow-left ${styles.goBackButtonIcon}`}
-            />
-            トップページへ戻る
-          </a>
-        </Link>
+        )}
+        <div className={styles.goBackButton}>
+          <Link href={pagesPath.$url()}>
+            <a className={styles.goBackButtonText}>
+              <span
+                className={`jam-icons jam-arrow-left ${styles.goBackButtonIcon}`}
+              />
+              トップページへ戻る
+            </a>
+          </Link>
+        </div>
       </div>
-    </div>
-  )
-}
-Announcement.layout = "default"
-Announcement.rbpac = { type: "public" }
+    )
+  }
+AnnouncementPage.layout = "default"
+AnnouncementPage.rbpac = { type: "public" }
 
-export default Announcement
+export default AnnouncementPage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,18 +13,17 @@ import {
   GENERAL_PROJECT_GUIDANCE_URL,
   GENERAL_PROJECT_GUIDANCE_2_URL,
 } from "src/constants/links"
-import { getRecentAnnouncements } from "src/lib/contentful"
-import { reportError } from "src/lib/errorTracking"
-import type { PromiseType } from "src/types/utils"
+import { getAnnouncements } from "src/lib/contentful"
+import { Announcement } from "src/types/models/announcement"
 import { pagesPath, staticPath } from "src/utils/$path"
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
 export const getStaticProps: GetStaticProps<{
-  announcements: PromiseType<ReturnType<typeof getRecentAnnouncements>>
+  announcements: Announcement[]
 }> = async () => {
-  const announcements = await getRecentAnnouncements({ limit: 100 })
+  const { announcements } = await getAnnouncements({ limit: 100 })
 
   return {
     props: {
@@ -37,10 +36,6 @@ export const getStaticProps: GetStaticProps<{
 const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   announcements,
 }) => {
-  if (!announcements || (announcements && "errorCode" in announcements)) {
-    reportError("failed to fetch announcements from Contentful", announcements)
-  }
-
   return (
     <div className={styles.wrapper}>
       <h1 className={styles.pageTitle}>雙峰祭オンラインシステム</h1>
@@ -157,9 +152,8 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <div className={styles.panelRowWrapper} data-cols="2">
           <div className={styles.panelWrapper}>
             <Panel>
-              {announcements && "errorCode" in announcements
-                ? "お知らせの取得に失敗しました"
-                : announcements.map(({ id, date, title }) => (
+              {announcements?.length
+                ? announcements.map(({ id, date, title }) => (
                     <Link href={pagesPath.announcement._id(id).$url()} key={id}>
                       <a>
                         <div className={styles.announcementRow}>
@@ -170,7 +164,8 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
                         </div>
                       </a>
                     </Link>
-                  ))}
+                  ))
+                : "お知らせの取得に失敗しました"}
             </Panel>
           </div>
           <div className={styles.panelWrapper}>


### PR DESCRIPTION
従来 `getStaticProps` などのサーバーサイドで生じた例外を無理やりクライアントまで持っていって `reportError` しており、かなり違法だったので