### PR TITLE
Display newline char in project description properly in project details page

### DIFF
--- a/src/pages/committee/project/details.tsx
+++ b/src/pages/committee/project/details.tsx
@@ -14,6 +14,7 @@ import {
   CopyButton,
   Icon,
   ProjectAttributeChips,
+  ParagraphWithUrlParsing,
 } from "src/components"
 import { useAuthNeue } from "src/contexts/auth"
 import { useToastDispatcher } from "src/contexts/toast"
@@ -253,7 +254,9 @@ const ProjectDetails: PageFC = () => {
               />
               <Table.Row
                 keyElement="説明文"
-                valueElement={project.description}
+                valueElement={
+                  <ParagraphWithUrlParsing text={project.description} />
+                }
               />
             </Table>
           </div>


### PR DESCRIPTION
`<ParagraphWithUrlParsing />` こういう用途にも明らかに便利なので `<Paragraph />` にリネームして URL parsing オプション扱いしても良いかもしれんな