### PR TITLE
Make use of native `notFound` support of Next.js in announcement fetching

### DIFF
--- a/src/pages/announcement/[id].tsx
+++ b/src/pages/announcement/[id].tsx
@@ -28,6 +28,14 @@ export const getStaticProps: GetStaticProps<
   { id: string }
 > = async ({ params }) => {
   const announcement = params ? await getAnnouncement({ id: params.id }) : null
+
+  if (!announcement) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    }
+  }
+
   return {
     props: {
       announcement,


### PR DESCRIPTION
announcement の取得に失敗した場合には404ページが表示されるようになる