### PR TITLE
Bugfix: Show "no announcements" message when announcement length is zero

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,7 +100,7 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <div className={styles.panelRowWrapper} data-cols="2">
           <div className={styles.panelWrapper}>
             <Panel>
-              {announcements?.length && announcements?.length !== 0 && (
+              {announcements?.length ? (
                 <ul className={styles.announcementsList}>
                   {announcements.map(({ id, date, title }) => (
                     <li className={styles.announcementsListItem} key={id}>
@@ -115,10 +115,11 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
                     </li>
                   ))}
                 </ul>
+              ) : announcements?.length === 0 ? (
+                "お知らせはありません"
+              ) : (
+                "お知らせの取得に失敗しました"
               )}
-              {announcements?.length === 0
-                ? "お知らせはありません"
-                : "お知らせの取得に失敗しました"}
               <div className={styles.moreAnnouncements}>
                 <Link href={pagesPath.announcement.list._page(1).$url()}>
                   <a className={styles.moreAnnouncementsLink}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -100,7 +100,7 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <div className={styles.panelRowWrapper} data-cols="2">
           <div className={styles.panelWrapper}>
             <Panel>
-              {announcements?.length ? (
+              {announcements?.length && announcements?.length !== 0 && (
                 <ul className={styles.announcementsList}>
                   {announcements.map(({ id, date, title }) => (
                     <li className={styles.announcementsListItem} key={id}>
@@ -115,9 +115,10 @@ const Index: PageFC<InferGetStaticPropsType<typeof getStaticProps>> = ({
                     </li>
                   ))}
                 </ul>
-              ) : (
-                "お知らせの取得に失敗しました"
               )}
+              {announcements?.length === 0
+                ? "お知らせはありません"
+                : "お知らせの取得に失敗しました"}
               <div className={styles.moreAnnouncements}>
                 <Link href={pagesPath.announcement.list._page(1).$url()}>
                   <a className={styles.moreAnnouncementsLink}>


### PR DESCRIPTION
お知らせの件数が0だった場合に"お知らせの取得に失敗しました"と表示するのではなく、"お知らせはありません"と表示するように修正