### PR TITLE
Set null when no value is selected

### DIFF
--- a/src/pages/project/form/answer.tsx
+++ b/src/pages/project/form/answer.tsx
@@ -529,7 +529,11 @@ const AnswerForm: PageFC = () => {
                             required={formItem.is_required}
                             register={register(
                               `items.${index}.answer` as const,
-                              { required: formItem.is_required }
+                              {
+                                required: formItem.is_required,
+                                setValueAs: (value: string) =>
+                                  value?.length ? value : null,
+                              }
                             )}
                           />
                         )

--- a/src/pages/project/registration-form/answer.tsx
+++ b/src/pages/project/registration-form/answer.tsx
@@ -798,6 +798,8 @@ const AnswerRegistrationForm: PageFC = () => {
                               `items.${index}.answer` as const,
                               {
                                 required: formItem.is_required,
+                                setValueAs: (value: string) =>
+                                  value?.length ? value : null,
                               }
                             )}
                             errors={[


### PR DESCRIPTION
`is_required: false` で `type: 'radio'` なitemに無回答で送信した際にエラーとなることがある問題の修正