### PR TITLE
Add a warning for an invalid s-address

### DIFF
--- a/src/components/TextField/index.module.scss
+++ b/src/components/TextField/index.module.scss
@@ -51,3 +51,9 @@
 .error {
   color: $color-caution;
 }
+
+.warning {
+  color: $color-text-sub;
+  font-weight: bold;
+  margin-top: 4px;
+}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -14,6 +14,7 @@ declare namespace TextField {
     description?: string[] | string
     descriptionUrlParsing?: boolean
     error?: Array<string | false | undefined> | string | false
+    warning?: Array<string | false | undefined> | string | false
     register?: UseFormRegisterReturn
   }> &
     JSX.IntrinsicElements["input"]
@@ -28,6 +29,7 @@ const TextField: FC<TextField.Props> = ({
   description,
   descriptionUrlParsing = false,
   error,
+  warning,
   autoComplete,
   register,
   ...restAttributes
@@ -36,6 +38,9 @@ const TextField: FC<TextField.Props> = ({
     Array.isArray(description) ? description : [description]
   ).filter((text): text is string => Boolean(text))
   const errors = (Array.isArray(error) ? error : [error]).filter(
+    (text): text is string => Boolean(text)
+  )
+  const warnings = (Array.isArray(warning) ? warning : [warning]).filter(
     (text): text is string => Boolean(text)
   )
 
@@ -77,6 +82,16 @@ const TextField: FC<TextField.Props> = ({
           {errors.map((text, index) => (
             <p className={styles.error} key={index}>
               {text}
+            </p>
+          ))}
+          {warnings.map((text, index) => (
+            <p className={styles.warning} key={index}>
+              {text.split("\n").map((line, lineIndex) => (
+                <>
+                  {line}
+                  {lineIndex < text.split("\n").length && <br />}
+                </>
+              ))}
             </p>
           ))}
         </div>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -23,6 +23,7 @@ const Signup: PageFC = () => {
     formState: { errors },
     setError,
     handleSubmit,
+    watch,
   } = useForm<Inputs>({
     criteriaMode: "all",
     mode: "onBlur",
@@ -82,6 +83,14 @@ const Signup: PageFC = () => {
       })
   }
 
+  const email = watch().email
+  const emailWarning = email
+    ? !watch().email.match(/^s[012][0-9]{6}@/) &&
+      watch().email.match(/@s\.tsukuba\.ac\.jp/)
+      ? "invalidSAddress"
+      : null
+    : null
+
   return (
     <div className={styles.wrapper}>
       <Head title="ユーザー登録" />
@@ -110,6 +119,10 @@ const Signup: PageFC = () => {
                       "使用できないメールアドレスです",
                     errors?.email?.type === "emailAlreadyInUse" &&
                       "このメールアドレスはユーザー登録済みです",
+                  ]}
+                  warning={[
+                    emailWarning === "invalidSAddress" &&
+                      "学生に発行されたsアドレスではない可能性があります。\nこのまま実行しますか？",
                   ]}
                   placeholder="xxx@s.tsukuba.ac.jp"
                   required


### PR DESCRIPTION
不正なsアドレスが入力された（末尾が `/s\.tsukuba\.ac\.jp$/` にマッチして冒頭が s +数字7桁でない）際に、注意を促す文言を表示

一桁多い
<img width="466" alt="image" src="https://user-images.githubusercontent.com/69859801/167815673-9aca2fd7-eb73-4d43-b1fd-ab76ff651d2e.png">

冒頭の s がない
<img width="494" alt="image" src="https://user-images.githubusercontent.com/69859801/167815737-48de5b72-a272-45e3-9bf9-bf710f632a8b.png">
