### PR TITLE
Add logout button on email verification page

### DIFF
--- a/src/pages/email-verification.module.scss
+++ b/src/pages/email-verification.module.scss
@@ -28,3 +28,7 @@
 .resendWrapper {
   margin-top: 32px;
 }
+
+.logoutButtonWrapper {
+  margin-top: 16px;
+}

--- a/src/pages/email-verification.tsx
+++ b/src/pages/email-verification.tsx
@@ -14,7 +14,7 @@ const EmailVerification: PageFC = () => {
     undefined | "mailSent" | "error"
   >(undefined)
 
-  const { sendEmailVerification } = useAuthNeue()
+  const { sendEmailVerification, signout } = useAuthNeue()
   const { addToast } = useToastDispatcher()
 
   const resendVerification = () => {
@@ -69,6 +69,21 @@ const EmailVerification: PageFC = () => {
                   fullWidth={true}
                 >
                   確認メールを再送する
+                </Button>
+              </div>
+              <div className={styles.logoutButtonWrapper}>
+                <Button
+                  icon="log-out-alt"
+                  kind="secondary"
+                  size="small"
+                  fullWidth={true}
+                  onClick={() => {
+                    if (window.confirm("ログアウトしますか?")) {
+                      signout()
+                    }
+                  }}
+                >
+                  ログアウト
                 </Button>
               </div>
             </>


### PR DESCRIPTION
メルアドの登録をミスるとユーザー側からは割とどうにもならなくなっていたのでどうにかしたかった

<img width="468" alt="スクリーンショット 2022-05-13 0 23 08" src="https://user-images.githubusercontent.com/25478531/168113190-c185cebd-1dc0-44bb-8c89-c5765628e47c.png">
