### PR TITLE
Fix the styles of the page for project index

### DIFF
--- a/src/pages/committee/project/index.module.scss
+++ b/src/pages/committee/project/index.module.scss
@@ -34,6 +34,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  @include mobile {
+    flex-direction: column;
+    justify-content: start;
+  }
 }
 
 .projectName {
@@ -41,6 +46,11 @@
   flex-shrink: 1;
   margin-right: 16px;
   @include ellipsis;
+
+  @include mobile {
+    width: 100%;
+    margin-right: 0;
+  }
 }
 
 .projectCodeWrapper {
@@ -50,6 +60,11 @@
   display: flex;
   align-items: center;
   color: $color-text-sub;
+
+  @include mobile {
+    width: 100%;
+    margin-right: 0;
+  }
 }
 
 .projectCodeCopyButton {
@@ -62,6 +77,11 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
+
+  @include mobile {
+    width: 100%;
+    margin-right: 0;
+  }
 }
 
 .projectCategory {


### PR DESCRIPTION
企画一覧の画面を狭小なディスプレイで表示すると表示されるべき項目が隠れたり、画面外に飛び出してしまったりすることがあったため修正しました

<img width="500" alt="image" src="https://user-images.githubusercontent.com/69859801/185474597-828ee9f8-a72a-456d-bcf2-44d0ed1c55f5.png">